### PR TITLE
Simplified vec2 creation

### DIFF
--- a/Example42/shader/fxaa.frag.glsl
+++ b/Example42/shader/fxaa.frag.glsl
@@ -74,7 +74,7 @@ void main(void)
 	float minSamplingDirectionFactor = 1.0 / (min(abs(samplingDirection.x), abs(samplingDirection.y)) + samplingDirectionReduce);
     
     // Calculate final sampling direction vector by reducing, clamping to a range and finally adapting to the texture size. 
-    samplingDirection = clamp(samplingDirection * minSamplingDirectionFactor, vec2(-u_maxSpan, -u_maxSpan), vec2(u_maxSpan, u_maxSpan)) * u_texelStep;
+    samplingDirection = clamp(samplingDirection * minSamplingDirectionFactor, vec2(-u_maxSpan), vec2(u_maxSpan)) * u_texelStep;
 	
 	// Inner samples on the tab.
 	vec3 rgbSampleNeg = texture(u_colorTexture, v_texCoord + samplingDirection * (1.0/3.0 - 0.5)).rgb;


### PR DESCRIPTION
GLSL allows to convert floats to vec2 in shorter way