### PR TITLE
Optimization

### DIFF
--- a/Example42/shader/fxaa.frag.glsl
+++ b/Example42/shader/fxaa.frag.glsl
@@ -53,7 +53,7 @@ void main(void)
 	float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
 	
 	// If contrast is lower than a maximum threshold ...
-	if (lumaMax - lumaMin < lumaMax * u_lumaThreshold)
+	if (lumaMax - lumaMin <= lumaMax * u_lumaThreshold)
 	{
 		// ... do no AA and return.
 		fragColor = vec4(rgbM, 1.0);


### PR DESCRIPTION
It makes sense to return earlier if we sample from plainly colored surface (e.g. full black) instead of AAing it.